### PR TITLE
Add q2view display application.

### DIFF
--- a/config/datatypes_conf.xml.sample
+++ b/config/datatypes_conf.xml.sample
@@ -189,8 +189,12 @@
     <datatype extension="nrrd" type="galaxy.datatypes.images:Nrrd" mimetype="image/nrrd"/>
     <datatype extension="nhdr" type="galaxy.datatypes.images:Nrrd" subclass="true"/>
     <datatype extension="rna_eps" type="galaxy.datatypes.sequence:RNADotPlotMatrix" mimetype="image/eps" display_in_upload="true"/>
-    <datatype extension="qza" type="galaxy.datatypes.qiime2:Qiime2Artifact" mimetype="application/octet-stream" display_in_upload="true"/>
-    <datatype extension="qzv" type="galaxy.datatypes.qiime2:Qiime2Visualization" mimetype="application/octet-stream" display_in_upload="true"/>
+    <datatype extension="qza" type="galaxy.datatypes.qiime2:Qiime2Artifact" mimetype="application/octet-stream" display_in_upload="true">
+      <display file="qiime/qiime2/q2view.xml"/>
+    </datatype>
+    <datatype extension="qzv" type="galaxy.datatypes.qiime2:Qiime2Visualization" mimetype="application/octet-stream" display_in_upload="true">
+      <display file="qiime/qiime2/q2view.xml"/>
+    </datatype>
     <datatype extension="zip" type="galaxy.datatypes.binary:CompressedZipArchive" display_in_upload="true"/>
     <datatype extension="tar" type="galaxy.datatypes.binary:CompressedArchive" subclass="true" display_in_upload="true"/>
     <!-- Proteomics Datatypes -->

--- a/config/tool_data_table_conf.xml.sample
+++ b/config/tool_data_table_conf.xml.sample
@@ -105,4 +105,9 @@
         <columns>value, name, url</columns>
         <file path="tool-data/intermine_simple_display.loc" />
     </table>
+    <!-- q2view servers -->
+    <table name="q2view_display" comment_char="#" allow_duplicate_entries="False">
+        <columns>value, name, url</columns>
+        <file path="tool-data/q2view_display.loc" />
+    </table>
 </tables>

--- a/display_applications/qiime/qiime2/q2view.xml
+++ b/display_applications/qiime/qiime2/q2view.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<display id="q2view" version="1.0.0" name="view at">
+    <dynamic_links from_data_table="q2view_display" skip_startswith="#" id="value" name="name">
+        <url>${ url % { 'q2view_file_url_qp': $q2view_file.qp } }</url>
+        <param type="data" name="q2view_file" url="galaxy_${DATASET_HASH}.${dataset.ext}" />
+    </dynamic_links>
+</display>

--- a/tool-data/q2view_display.loc.sample
+++ b/tool-data/q2view_display.loc.sample
@@ -1,3 +1,3 @@
-# Table used for listing simple Intermine display servers
+# Table used for listing QIIME2View display servers
 #<unique_id>	<display_name>	<url>
 main_q2view	qiime2view	https://view.qiime2.org/visualization/?type=html&src=%(q2view_file_url_qp)s

--- a/tool-data/q2view_display.loc.sample
+++ b/tool-data/q2view_display.loc.sample
@@ -1,0 +1,3 @@
+# Table used for listing simple Intermine display servers
+#<unique_id>	<display_name>	<url>
+main_q2view	qiime2view	https://view.qiime2.org/visualization/?type=html&src=%(q2view_file_url_qp)s


### PR DESCRIPTION
Requires configuring CORS and using https on Galaxy with these default settings.